### PR TITLE
feat: separate human notes from AI summaries

### DIFF
--- a/granola_mcp/cli/commands/export.py
+++ b/granola_mcp/cli/commands/export.py
@@ -63,7 +63,13 @@ class ExportCommand:
         parser.add_argument(
             '--no-summary',
             action='store_true',
-            help='Exclude summary/notes from export'
+            help='Exclude AI summary from export'
+        )
+
+        parser.add_argument(
+            '--no-notes',
+            action='store_true',
+            help='Exclude human notes from export'
         )
 
         parser.add_argument(
@@ -143,6 +149,7 @@ class ExportCommand:
         include_metadata = not self.args.no_metadata
         include_participants = not self.args.no_participants
         include_summary = not self.args.no_summary
+        include_notes = not self.args.no_notes
         include_tags = not self.args.no_tags
         include_speakers = not self.args.no_speakers
         include_timestamps = self.args.timestamps
@@ -153,6 +160,7 @@ class ExportCommand:
             include_metadata=include_metadata,
             include_participants=include_participants,
             include_summary=include_summary,
+            include_notes=include_notes,
             include_tags=include_tags,
             include_speakers=include_speakers,
             include_timestamps=include_timestamps

--- a/granola_mcp/cli/commands/show.py
+++ b/granola_mcp/cli/commands/show.py
@@ -53,7 +53,13 @@ class ShowCommand:
         parser.add_argument(
             '--notes',
             action='store_true',
-            help='Include meeting notes/summary'
+            help='Include human-taken meeting notes'
+        )
+
+        parser.add_argument(
+            '--summary',
+            action='store_true',
+            help='Include AI-generated meeting summary'
         )
 
         parser.add_argument(
@@ -65,7 +71,7 @@ class ShowCommand:
         parser.add_argument(
             '--all',
             action='store_true',
-            help='Show all available information (equivalent to --transcript --notes --metadata)'
+            help='Show all available information (equivalent to --transcript --notes --summary --metadata)'
         )
 
         # Transcript formatting options
@@ -169,7 +175,7 @@ class ShowCommand:
 
     def _show_summary(self, meeting: Meeting) -> None:
         """
-        Show meeting summary/notes.
+        Show AI-generated meeting summary.
 
         Args:
             meeting: Meeting to display
@@ -178,8 +184,22 @@ class ShowCommand:
         if not summary:
             return
 
-        print_section("Summary")
+        print_section("AI Summary")
         print(summary)
+
+    def _show_human_notes(self, meeting: Meeting) -> None:
+        """
+        Show human-taken meeting notes.
+
+        Args:
+            meeting: Meeting to display
+        """
+        notes = meeting.human_notes
+        if not notes:
+            return
+
+        print_section("Human Notes")
+        print(notes)
 
     def _show_tags(self, meeting: Meeting) -> None:
         """
@@ -301,6 +321,7 @@ class ShowCommand:
             # Determine what to show
             show_transcript = self.args.transcript or self.args.all
             show_notes = self.args.notes or self.args.all
+            show_summary = self.args.summary or self.args.all
             show_metadata = self.args.metadata or self.args.all
 
             # Show basic information
@@ -309,8 +330,12 @@ class ShowCommand:
             # Show participants
             self._show_participants(meeting)
 
-            # Show summary/notes
+            # Show human notes
             if show_notes:
+                self._show_human_notes(meeting)
+
+            # Show AI summary
+            if show_summary:
                 self._show_summary(meeting)
 
             # Show tags

--- a/granola_mcp/cli/formatters/markdown.py
+++ b/granola_mcp/cli/formatters/markdown.py
@@ -128,22 +128,45 @@ def format_participants_section(meeting: Meeting) -> str:
 
 def format_summary_section(meeting: Meeting) -> str:
     """
-    Format summary/notes section in markdown.
+    Format AI summary section in markdown.
 
     Args:
         meeting: Meeting object
 
     Returns:
-        str: Formatted markdown summary section
+        str: Formatted markdown AI summary section
     """
     summary = meeting.summary
     if not summary:
         return ""
 
     lines = []
-    lines.append("## Summary")
+    lines.append("## AI Summary")
     lines.append("")
     lines.append(escape_markdown(summary))
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+def format_notes_section(meeting: Meeting) -> str:
+    """
+    Format human notes section in markdown.
+
+    Args:
+        meeting: Meeting object
+
+    Returns:
+        str: Formatted markdown human notes section
+    """
+    notes = meeting.human_notes
+    if not notes:
+        return ""
+
+    lines = []
+    lines.append("## Human Notes")
+    lines.append("")
+    lines.append(escape_markdown(notes))
     lines.append("")
 
     return "\n".join(lines)
@@ -240,8 +263,9 @@ def format_tags_section(meeting: Meeting) -> str:
 
 def export_meeting_to_markdown(meeting: Meeting, include_transcript: bool = True,
                               include_metadata: bool = True, include_participants: bool = True,
-                              include_summary: bool = True, include_tags: bool = True,
-                              include_speakers: bool = True, include_timestamps: bool = False) -> str:
+                              include_summary: bool = True, include_notes: bool = True,
+                              include_tags: bool = True, include_speakers: bool = True,
+                              include_timestamps: bool = False) -> str:
     """
     Export a complete meeting to markdown format.
 
@@ -250,7 +274,8 @@ def export_meeting_to_markdown(meeting: Meeting, include_transcript: bool = True
         include_transcript: Whether to include transcript
         include_metadata: Whether to include metadata
         include_participants: Whether to include participants
-        include_summary: Whether to include summary/notes
+        include_summary: Whether to include AI summary
+        include_notes: Whether to include human notes
         include_tags: Whether to include tags
         include_speakers: Whether to include speaker names in transcript
         include_timestamps: Whether to include timestamps in transcript
@@ -275,7 +300,13 @@ def export_meeting_to_markdown(meeting: Meeting, include_transcript: bool = True
         if participants_section.strip():
             sections.append(participants_section)
 
-    # Summary
+    # Human Notes
+    if include_notes:
+        notes_section = format_notes_section(meeting)
+        if notes_section.strip():
+            sections.append(notes_section)
+
+    # AI Summary
     if include_summary:
         summary_section = format_summary_section(meeting)
         if summary_section.strip():

--- a/granola_mcp/cli/main.py
+++ b/granola_mcp/cli/main.py
@@ -47,6 +47,12 @@ Examples:
   # Show meeting with transcript
   granola show <meeting-id> --transcript
 
+  # Show meeting with human notes
+  granola show <meeting-id> --notes
+
+  # Show meeting with AI summary
+  granola show <meeting-id> --summary
+
   # Export meeting to markdown
   granola export <meeting-id>
   granola export <meeting-id> > meeting.md

--- a/granola_mcp/core/meeting.py
+++ b/granola_mcp/core/meeting.py
@@ -151,11 +151,20 @@ class Meeting:
 
     @property
     def summary(self) -> Optional[str]:
-        """Get the meeting summary."""
-        # Try different possible summary fields
-        for summary_field in ['summary', 'description', 'notes', 'overview']:
+        """Get the AI-generated meeting summary."""
+        # Try different possible AI summary fields
+        for summary_field in ['summary', 'ai_summary', 'description', 'overview']:
             if summary_field in self._data:
                 return str(self._data[summary_field])
+        return None
+
+    @property
+    def human_notes(self) -> Optional[str]:
+        """Get the human-taken meeting notes."""
+        # Try different possible human notes fields
+        for notes_field in ['notes', 'human_notes', 'user_notes', 'manual_notes']:
+            if notes_field in self._data:
+                return str(self._data[notes_field])
         return None
 
     @property


### PR DESCRIPTION
Fixes #2

This PR implements the requested feature to separate human-taken notes from AI-generated summaries in the GranolaMCP CLI tool.

## Changes

- **Core Data Model**: Added separate `human_notes` property to Meeting class
- **Show Command**: Updated `--notes` for human notes, added `--summary` for AI summaries
- **Export Command**: Added `--no-notes` flag and updated `--no-summary` behavior
- **Markdown Formatting**: Separate sections for "Human Notes" and "AI Summary"
- **CLI Help**: Updated examples and documentation

## Usage

```bash
# Show human notes only
granola show <meeting-id> --notes

# Show AI summary only
granola show <meeting-id> --summary

# Show both
granola show <meeting-id> --notes --summary
```

Generated with [Claude Code](https://claude.ai/code)