### PR TITLE
fix: correct ASCII table right border alignment

### DIFF
--- a/granola_mcp/cli/formatters/charts.py
+++ b/granola_mcp/cli/formatters/charts.py
@@ -438,7 +438,7 @@ def create_summary_box(stats: Dict[str, Any], title: str = "Meeting Statistics")
         colored_value = colorize(value_str, Colors.BRIGHT_CYAN)
         content = f"{key}: {colored_value}"
         # Calculate padding using original value_str length (without color codes)
-        padding = box_width - len(key) - len(value_str) - 4
+        padding = box_width - len(key) - len(value_str) - 5
         line = ChartConfig.VERTICAL + f" {content}" + " " * padding + ChartConfig.VERTICAL
         lines.append(line)
 


### PR DESCRIPTION
Fixes the remaining ASCII table alignment issue from PR #7.

The padding calculation in create_summary_box() was off by one character. 
Line structure is: │ content padding │ which requires 5 characters to be subtracted from box_width, not 4.

Generated with [Claude Code](https://claude.ai/code)