### PR TITLE
docs: clarify cache-only data source approach and mention API alternative

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4,6 +4,17 @@
 
 A Python 3.12+ library providing programmatic, CLI, and MCP access to Granola.ai meeting data with live JSON parsing, beautiful terminal output, and comprehensive meeting management capabilities. **100% Native Python - No External Dependencies**.
 
+### Data Access Strategy
+
+**GranolaMCP uses a cache-based approach exclusively** - all data is read directly from Granola's local cache file (`cache-v3.json`) without any network communication. This design choice provides:
+
+- **Offline Operation**: Complete functionality without internet connectivity
+- **Performance**: Direct file system access eliminates API latency
+- **Privacy**: Meeting data remains on the local machine
+- **Reliability**: No dependency on Granola's server availability
+
+**Note**: While it would be technically feasible to implement API-based access by extracting authentication tokens from Granola's `supabase.json` configuration, this library intentionally focuses on the cache-based approach for optimal user experience.
+
 ## Project Structure
 
 ```

--- a/README.md
+++ b/README.md
@@ -11,6 +11,17 @@ GranolaMCP provides complete access to Granola.ai meeting data through multiple 
 - **🤖 MCP Server** - Model Context Protocol server for AI integration (Claude, etc.)
 - **📊 Analytics & Visualization** - Comprehensive statistics with ASCII charts
 
+## Data Source
+
+**GranolaMCP operates entirely on local cache files** - it reads meeting data directly from Granola's local cache file (`cache-v3.json`) without making any API calls to Granola's servers. This approach provides:
+
+- **🔌 No Network Dependency** - Works completely offline
+- **⚡ Fast Access** - Direct file system access with no API rate limits  
+- **🔒 Privacy Focused** - Your meeting data never leaves your machine
+- **🛡️ No Authentication** - No need to manage API keys or tokens
+
+**Alternative Approach Available:** While not implemented in this library, it's technically possible to extract access tokens from Granola's `supabase.json` configuration file and communicate directly with the Granola API. However, the cache-based approach provides better performance, privacy, and reliability for most use cases.
+
 ## ✨ Key Features
 
 ### Core Data Access

--- a/docs/MCP-USAGE.md
+++ b/docs/MCP-USAGE.md
@@ -2,6 +2,8 @@
 
 This guide provides comprehensive instructions for manually running the GranolaMCP MCP (Model Context Protocol) server, configuring it, testing it, and integrating it with LLM systems.
 
+**Data Source Note**: The MCP server operates exclusively on Granola's local cache file (`cache-v3.json`) and does not make any network requests to Granola's API. This ensures privacy, performance, and offline operation. While API-based access would be technically possible using credentials from Granola's `supabase.json` file, this implementation focuses on the cache-based approach.
+
 ## Table of Contents
 
 1. [Basic MCP Server Startup](#basic-mcp-server-startup)

--- a/docs/README-JSON.md
+++ b/docs/README-JSON.md
@@ -6,6 +6,8 @@ This document provides a comprehensive analysis of the Granola.ai cache JSON str
 
 The Granola.ai cache file (`cache-v3.json`) contains a nested JSON structure with the main data stored under a `cache` key that itself contains a JSON string requiring double parsing.
 
+**Important**: GranolaMCP operates exclusively on this local cache file and does not communicate with Granola's API servers. While it would be possible to extract authentication credentials from Granola's `supabase.json` configuration and make direct API calls, this library intentionally uses the cache-based approach for better performance, privacy, and offline operation.
+
 ```python
 # Loading pattern
 data = json.loads(open("cache-v3.json").read())


### PR DESCRIPTION
This PR addresses issue #10 by updating documentation to clearly explain that GranolaMCP operates entirely on local cache files.

## Changes

- **README.md**: Added "Data Source" section explaining cache-only approach
- **ARCHITECTURE.md**: Added "Data Access Strategy" section with technical details
- **docs/README-JSON.md**: Updated overview to clarify cache-only operation
- **docs/MCP-USAGE.md**: Added data source note at the beginning

## Key Points Clarified

1. GranolaMCP operates **exclusively** on local cache files
2. No API calls are made to Granola's servers
3. API access via supabase.json token extraction is technically possible but not implemented
4. Benefits of cache-based approach: offline operation, privacy, performance, no authentication

Closes #10

Generated with [Claude Code](https://claude.ai/code)