### PR TITLE
fix: resolve timezone inconsistency in time-based meeting queries

### DIFF
--- a/granola_mcp/mcp/tools.py
+++ b/granola_mcp/mcp/tools.py
@@ -13,6 +13,7 @@ from typing import Dict, Any, List, Optional, Union
 from ..core.parser import GranolaParser, GranolaParseError
 from ..core.meeting import Meeting
 from ..utils.date_parser import parse_date, get_date_range
+from ..core.timezone_utils import get_cst_timezone
 from ..cli.formatters.markdown import export_meeting_to_markdown
 
 
@@ -76,16 +77,18 @@ class MCPTools:
             return meetings
 
         try:
+            cst_tz = get_cst_timezone()
+            
             if from_date and to_date:
                 start_date, end_date = get_date_range(from_date, to_date)
             elif from_date:
                 start_date = parse_date(from_date)
-                end_date = datetime.datetime.now(start_date.tzinfo)
+                end_date = datetime.datetime.now(cst_tz)
             else:
                 # Only to_date specified
                 if to_date:
                     end_date = parse_date(to_date)
-                    start_date = datetime.datetime.min.replace(tzinfo=end_date.tzinfo)
+                    start_date = datetime.datetime.min.replace(tzinfo=cst_tz)
                 else:
                     return meetings
 


### PR DESCRIPTION
Fixed issue where MCP time-based queries (like "past 24 hours") would fail while limit-based queries worked correctly.

**Root cause:** In _filter_meetings_by_date(), when using start_date.tzinfo to create end_date, timezone inconsistencies could cause comparison failures.

**Changes:**
- Import get_cst_timezone for consistent timezone handling
- Use explicit CST timezone instead of inferring from start_date.tzinfo
- Ensures all date comparisons use consistent CST timezone

Fixes #12

Generated with [Claude Code](https://claude.ai/code)