### PR TITLE
fix: update Git URLs from granola-mcp to GranolaMCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ GranolaMCP provides complete access to Granola.ai meeting data through multiple 
 
 ```bash
 # Install from source
-git clone https://github.com/pedramamini/granola-mcp.git
-cd granola-mcp
+git clone https://github.com/pedramamini/GranolaMCP.git
+cd GranolaMCP
 pip install -e .
 
 # Or install from PyPI (when available)

--- a/docs/MCP-USAGE.md
+++ b/docs/MCP-USAGE.md
@@ -591,7 +591,7 @@ If you encounter issues not covered here:
 1. **Check the logs:** Always run with `--debug` first
 2. **Verify your setup:** Ensure cache file exists and is readable
 3. **Test with minimal data:** Try with a small cache file first
-4. **Check the GitHub issues:** [https://github.com/pedramamini/granola-mcp/issues](https://github.com/pedramamini/granola-mcp/issues)
+4. **Check the GitHub issues:** [https://github.com/pedramamini/GranolaMCP/issues](https://github.com/pedramamini/GranolaMCP/issues)
 
 ---
 

--- a/granola_mcp/mcp/__main__.py
+++ b/granola_mcp/mcp/__main__.py
@@ -39,7 +39,7 @@ The server communicates via STDIO using JSON-RPC 2.0 following the MCP protocol.
     parser.add_argument(
         "--version",
         action="version",
-        version="granola-mcp 1.0.0"
+        version="GranolaMCP 1.0.0"
     )
 
     args = parser.parse_args()

--- a/granola_mcp/mcp/server.py
+++ b/granola_mcp/mcp/server.py
@@ -38,7 +38,7 @@ class MCPServer:
 
         # MCP server info
         self.server_info = {
-            "name": "granola-mcp",
+            "name": "GranolaMCP",
             "version": "1.0.0",
             "description": "MCP server for Granola.ai meeting data access and analytics"
         }

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     description="A Python library for interfacing with Granola.ai meeting data",
     long_description=read_readme(),
     long_description_content_type="text/markdown",
-    url="https://github.com/pedramamini/granola-mcp",
+    url="https://github.com/pedramamini/GranolaMCP",
     packages=find_packages(),
     classifiers=[
         "Development Status :: 3 - Alpha",
@@ -78,8 +78,8 @@ setup(
         "model-context-protocol",
     ],
     project_urls={
-        "Bug Reports": "https://github.com/pedramamini/granola-mcp/issues",
-        "Source": "https://github.com/pedramamini/granola-mcp",
-        "Documentation": "https://github.com/pedramamini/granola-mcp/blob/main/README.md",
+        "Bug Reports": "https://github.com/pedramamini/GranolaMCP/issues",
+        "Source": "https://github.com/pedramamini/GranolaMCP",
+        "Documentation": "https://github.com/pedramamini/GranolaMCP/blob/main/README.md",
     },
 )


### PR DESCRIPTION
Updates all Git URL references to use the correct repository name (GranolaMCP) instead of the old name (granola-mcp).

**Changes:**
- Update README.md git clone URL and directory name
- Fix all setup.py URL references (main url, Bug Reports, Source, Documentation)
- Update docs/MCP-USAGE.md GitHub issues link
- Update version string in granola_mcp/mcp/__main__.py
- Update server name in granola_mcp/mcp/server.py

Fixes #14

Generated with [Claude Code](https://claude.ai/code)