### PR TITLE
feat: fetch remote transcripts across CLI/MCP

### DIFF
--- a/granola_mcp/cli/commands/collect.py
+++ b/granola_mcp/cli/commands/collect.py
@@ -87,6 +87,12 @@ class CollectCommand:
             help='Minimum words required to include a segment (default: 1)'
         )
 
+        parser.add_argument(
+            '--no-remote',
+            action='store_true',
+            help='Do not fetch transcripts remotely (only use cached/local transcript data)'
+        )
+
     def _get_date_range(self) -> Tuple[Optional[datetime], Optional[datetime]]:
         """
         Get the date range for collection.
@@ -150,7 +156,7 @@ class CollectCommand:
         
         for meeting in meetings:
             transcript = meeting.transcript
-            if not transcript:
+            if transcript is None:
                 continue
                 
             # Get my words from this meeting
@@ -242,8 +248,9 @@ class CollectCommand:
 
             # Get meetings in date range
             meetings = []
+            remote_enabled = not getattr(self.args, 'no_remote', False)
             for meeting_data in self.parser.get_meetings():
-                meeting = Meeting(meeting_data)
+                meeting = Meeting(meeting_data).set_remote_fetch_enabled(remote_enabled)
                 if meeting.start_time and start_date <= meeting.start_time <= end_date:
                     meetings.append(meeting)
 

--- a/granola_mcp/cli/commands/export.py
+++ b/granola_mcp/cli/commands/export.py
@@ -104,6 +104,12 @@ class ExportCommand:
             help='Override meeting title in export'
         )
 
+        parser.add_argument(
+            '--no-remote',
+            action='store_true',
+            help='Do not fetch transcripts remotely (only use cached/local transcript data)'
+        )
+
     def _find_meeting(self, meeting_id: str) -> Optional[Meeting]:
         """
         Find a meeting by ID.
@@ -116,14 +122,14 @@ class ExportCommand:
         """
         meeting_data = self.parser.get_meeting_by_id(meeting_id)
         if meeting_data:
-            return Meeting(meeting_data)
+            return Meeting(meeting_data).set_remote_fetch_enabled(not self.args.no_remote)
 
         # Try partial ID match
         all_meetings = self.parser.get_meetings()
         for data in all_meetings:
             meeting = Meeting(data)
             if meeting.id and meeting.id.startswith(meeting_id):
-                return meeting
+                return meeting.set_remote_fetch_enabled(not self.args.no_remote)
 
         return None
 
@@ -142,7 +148,7 @@ class ExportCommand:
             # Create a copy of the meeting data with custom title
             meeting_data = meeting.raw_data.copy()
             meeting_data['title'] = self.args.title
-            meeting = Meeting(meeting_data)
+            meeting = Meeting(meeting_data).set_remote_fetch_enabled(not self.args.no_remote)
 
         # Determine what to include
         include_transcript = not self.args.no_transcript

--- a/granola_mcp/cli/commands/list.py
+++ b/granola_mcp/cli/commands/list.py
@@ -115,6 +115,18 @@ class ListCommand:
             help='Hide table header'
         )
 
+        parser.add_argument(
+            '--fetch-transcripts',
+            action='store_true',
+            help='Fetch transcripts remotely when they are not cached locally (may be slow)'
+        )
+
+        parser.add_argument(
+            '--no-remote',
+            action='store_true',
+            help='Do not fetch transcripts remotely (only use cached/local transcript data)'
+        )
+
     def _filter_meetings_by_date(self, meetings: List[Meeting]) -> List[Meeting]:
         """
         Filter meetings by date criteria.
@@ -352,6 +364,11 @@ class ListCommand:
                         transcript_str = f"{word_count // 1000:.1f}k"
                     else:
                         transcript_str = str(word_count)
+                else:
+                    # Surface "present but empty" transcripts
+                    transcript_str = muted("0")
+            elif meeting.has_transcript_link():
+                transcript_str = muted("link")
 
             # Get AI summary word count
             summary_str = muted("--")
@@ -457,7 +474,8 @@ class ListCommand:
             # Load meetings with debug flag if verbose is enabled
             debug_flag = getattr(self.args, 'verbose', False)
             meeting_data = self.parser.get_meetings(debug=debug_flag)
-            meetings = [Meeting(data) for data in meeting_data]
+            remote_enabled = not getattr(self.args, 'no_remote', False)
+            meetings = [Meeting(data).set_remote_fetch_enabled(remote_enabled) for data in meeting_data]
 
             if self.args.verbose:
                 print_info(f"Loaded {len(meetings)} meetings from cache")
@@ -474,6 +492,22 @@ class ListCommand:
             # Apply limit
             if self.args.limit and self.args.limit > 0:
                 meetings = meetings[:self.args.limit]
+
+            # Resolve transcripts remotely for the meetings we're about to display.
+            # Default is enabled (Meeting default/env); explicit opt-out is --no-remote.
+            # --fetch-transcripts acts as a force-enable switch.
+            if getattr(self.args, 'fetch_transcripts', False):
+                remote_enabled = True
+
+            if remote_enabled:
+                if self.args.verbose:
+                    print_info(f"Fetching remote transcripts for {len(meetings)} meetings (best-effort)...")
+                for meeting in meetings:
+                    try:
+                        meeting.ensure_transcript(fetch_remote=True)
+                    except Exception:
+                        # Best-effort: keep listing even if a remote fetch fails.
+                        pass
 
             # Format output
             if self.args.format == 'simple':

--- a/granola_mcp/cli/commands/show.py
+++ b/granola_mcp/cli/commands/show.py
@@ -74,6 +74,12 @@ class ShowCommand:
             help='Show all available information (equivalent to --transcript --notes --summary --metadata)'
         )
 
+        parser.add_argument(
+            '--no-remote',
+            action='store_true',
+            help='Do not fetch transcript remotely when it is not cached locally'
+        )
+
         # Transcript formatting options
         parser.add_argument(
             '--no-speakers',
@@ -105,14 +111,14 @@ class ShowCommand:
         """
         meeting_data = self.parser.get_meeting_by_id(meeting_id)
         if meeting_data:
-            return Meeting(meeting_data)
+            return Meeting(meeting_data).set_remote_fetch_enabled(not self.args.no_remote)
 
         # Try partial ID match
         all_meetings = self.parser.get_meetings()
         for data in all_meetings:
             meeting = Meeting(data)
             if meeting.id and meeting.id.startswith(meeting_id):
-                return meeting
+                return meeting.set_remote_fetch_enabled(not self.args.no_remote)
 
         return None
 
@@ -151,8 +157,10 @@ class ShowCommand:
         if participants:
             details.append(("Participants", f"{len(participants)} attendees"))
 
-        if meeting.has_transcript():
+        if meeting.has_transcript(fetch_remote=not self.args.no_remote):
             details.append(("Transcript", "Available"))
+        elif meeting.has_transcript_link():
+            details.append(("Transcript", "Linked"))
         else:
             details.append(("Transcript", muted("Not available")))
 
@@ -263,9 +271,16 @@ class ShowCommand:
         Args:
             meeting: Meeting to display
         """
+        # Best-effort: fetch remotely when not cached.
+        meeting.ensure_transcript(fetch_remote=not self.args.no_remote)
         transcript = meeting.transcript
-        if not transcript:
-            print_info("No transcript available for this meeting.")
+        if transcript is None:
+            transcript_url = meeting.transcript_url
+            if transcript_url:
+                print_info("Transcript is not cached locally for this meeting.")
+                print_info(f"Open: {transcript_url}")
+            else:
+                print_info("No transcript available for this meeting.")
             return
 
         print_section("Transcript")
@@ -335,6 +350,10 @@ class ShowCommand:
             show_notes = self.args.notes or self.args.all
             show_summary = self.args.summary or self.args.all
             show_metadata = self.args.metadata or self.args.all
+
+            # If the user asked for transcript output, try to resolve it (including remote).
+            if show_transcript:
+                meeting.ensure_transcript(fetch_remote=not self.args.no_remote)
 
             # Show basic information
             self._show_basic_info(meeting)

--- a/granola_mcp/cli/commands/stats.py
+++ b/granola_mcp/cli/commands/stats.py
@@ -143,6 +143,12 @@ class StatsCommand:
             help='Width for ASCII charts'
         )
 
+        parser.add_argument(
+            '--no-remote',
+            action='store_true',
+            help='Do not fetch transcripts remotely (only use cached/local transcript data)'
+        )
+
     def _filter_meetings_by_date(self, meetings: List[Meeting]) -> List[Meeting]:
         """
         Filter meetings by date criteria.
@@ -534,7 +540,7 @@ class StatsCommand:
         total_words = 0
 
         for meeting in meetings:
-            if meeting.has_transcript() and meeting.transcript:
+            if meeting.has_transcript() and meeting.transcript is not None:
                 meetings_with_transcripts += 1
                 # Simple word count (split by whitespace)
                 transcript_text = meeting.transcript.full_text
@@ -637,7 +643,8 @@ class StatsCommand:
         try:
             # Load meetings
             meeting_data = self.parser.get_meetings()
-            meetings = [Meeting(data) for data in meeting_data]
+            remote_enabled = not getattr(self.args, 'no_remote', False)
+            meetings = [Meeting(data).set_remote_fetch_enabled(remote_enabled) for data in meeting_data]
 
             if self.args.verbose:
                 print_info(f"Loaded {len(meetings)} meetings from cache")

--- a/granola_mcp/cli/formatters/markdown.py
+++ b/granola_mcp/cli/formatters/markdown.py
@@ -185,8 +185,9 @@ def format_transcript_section(meeting: Meeting, include_speakers: bool = True,
     Returns:
         str: Formatted markdown transcript section
     """
+    meeting.ensure_transcript(fetch_remote=True)
     transcript = meeting.transcript
-    if not transcript:
+    if transcript is None:
         return ""
 
     lines = []

--- a/granola_mcp/core/meeting.py
+++ b/granola_mcp/core/meeting.py
@@ -6,9 +6,24 @@ Granola.ai meeting objects.
 """
 
 import datetime
+import os
+import re
 from typing import Dict, Any, List, Optional
 from .timezone_utils import convert_utc_to_cst
 from .transcript import Transcript
+from .remote_api import GranolaAPIClient
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    value = str(value).strip().lower()
+    if value in {"1", "true", "yes", "y", "on"}:
+        return True
+    if value in {"0", "false", "no", "n", "off"}:
+        return False
+    return default
 
 
 class Meeting:
@@ -25,6 +40,15 @@ class Meeting:
         """
         self._data = meeting_data
         self._transcript: Optional[Transcript] = None
+        self._remote_transcript_attempted: bool = False
+        # Remote transcript fetching is enabled by default so all CLI/MCP methods can
+        # resolve transcripts even when the local cache is missing chunks.
+        # Opt out with env var GRANOLA_FETCH_REMOTE_TRANSCRIPTS=0 or per-command flags.
+        self._remote_fetch_enabled: bool = _env_bool("GRANOLA_FETCH_REMOTE_TRANSCRIPTS", True)
+
+    def set_remote_fetch_enabled(self, enabled: bool) -> "Meeting":
+        self._remote_fetch_enabled = bool(enabled)
+        return self
 
     @property
     def id(self) -> Optional[str]:
@@ -251,24 +275,109 @@ class Meeting:
     @property
     def transcript(self) -> Optional[Transcript]:
         """Get the meeting transcript."""
-        if self._transcript is None:
-            # Try to find transcript data
-            transcript_data = None
+        self._resolve_cached_transcript()
 
-            # Check for transcript_data field added by parser
-            if 'transcript_data' in self._data:
-                transcript_data = self._data['transcript_data']
-            else:
-                # Fallback to other possible transcript fields
-                for transcript_field in ['transcript', 'transcription', 'content', 'text']:
-                    if transcript_field in self._data:
-                        transcript_data = self._data[transcript_field]
-                        break
-
-            if transcript_data:
-                self._transcript = Transcript(transcript_data)
+        # If transcript is still missing and remote fetch is enabled, try to fetch.
+        if self._transcript is None and self._remote_fetch_enabled:
+            self.ensure_transcript(fetch_remote=True)
 
         return self._transcript
+
+    def _resolve_cached_transcript(self) -> Optional[Transcript]:
+        """Resolve transcript from cached/local meeting payload only (no network)."""
+        if self._transcript is not None:
+            return self._transcript
+
+        transcript_data = None
+
+        # Check for transcript_data field added by parser
+        if 'transcript_data' in self._data:
+            transcript_data = self._data['transcript_data']
+        else:
+            # Fallback to other possible transcript fields
+            for transcript_field in ['transcript', 'transcription', 'content', 'text']:
+                if transcript_field in self._data:
+                    transcript_data = self._data[transcript_field]
+                    break
+
+        # Important: Granola caches can include an explicit transcript entry that is an
+        # empty list (e.g. transcript exists but segments are not yet present). Treat
+        # "present but empty" as a valid transcript payload.
+        if transcript_data is not None:
+            self._transcript = Transcript(transcript_data)
+
+        return self._transcript
+
+    def ensure_transcript(self, fetch_remote: Optional[bool] = True) -> Optional[Transcript]:
+        """Ensure a transcript is available, fetching remotely when needed.
+
+        This is best-effort and safe to call repeatedly. It will not raise on
+        remote failures; instead it will leave transcript unset.
+
+        Args:
+            fetch_remote: If True, attempt remote fetch when transcript is not cached.
+
+        Returns:
+            Optional[Transcript]: The resolved transcript (cached or fetched), or None.
+        """
+
+        # First, try cached/local transcript resolution.
+        if self._resolve_cached_transcript() is not None:
+            return self._transcript
+
+        if fetch_remote is None:
+            fetch_remote = self._remote_fetch_enabled
+
+        if not fetch_remote:
+            return None
+
+        if self._remote_transcript_attempted:
+            return self._transcript
+
+        self._remote_transcript_attempted = True
+
+        # Prefer the document id, but fall back to transcript share URL id if needed.
+        document_id = self.id
+        if not document_id:
+            url = self.transcript_url
+            if isinstance(url, str) and url.strip():
+                m = re.search(r"https?://notes\.granola\.ai/t/(?P<id>[A-Za-z0-9\-]+)", url)
+                if m:
+                    document_id = m.group("id")
+
+        if not document_id:
+            return None
+
+        try:
+            workspace_id = None
+            if isinstance(self._data, dict):
+                workspace_id = self._data.get("workspace_id") or self._data.get("workspaceId")
+            client = GranolaAPIClient.from_local_app_data(workspace_id=workspace_id)
+            payload = client.get_document_transcript(document_id)
+        except Exception:
+            return None
+
+        if payload is None:
+            return None
+
+        # Cache the fetched payload on this meeting instance.
+        self._data["transcript_data"] = payload
+        self._transcript = Transcript(payload)
+        return self._transcript
+
+    def has_transcript(self, fetch_remote: Optional[bool] = None) -> bool:
+        """Return True if a transcript is available.
+
+        When remote fetching is enabled, this will best-effort fetch missing transcripts
+        from the Granola backend so all CLI/MCP commands get consistent results.
+        """
+        if fetch_remote is None:
+            fetch_remote = self._remote_fetch_enabled
+        if fetch_remote:
+            self.ensure_transcript(fetch_remote=True)
+        else:
+            self._resolve_cached_transcript()
+        return self._transcript is not None
 
     def _extract_text_from_structured_content(self, content_list: List[Dict]) -> str:
         """Extract plain text from Granola's structured content format."""
@@ -410,9 +519,28 @@ class Meeting:
         """
         return self._data.get(field_name, default)
 
-    def has_transcript(self) -> bool:
-        """Check if the meeting has transcript data."""
-        return self.transcript is not None
+    @property
+    def transcript_url(self) -> Optional[str]:
+        """Best-effort transcript share URL (when transcript text isn't cached locally)."""
+        if not self._data:
+            return None
+
+        haystacks: List[str] = []
+        for key in ('ai_summary_html', 'notes_markdown', 'notes_plain'):
+            value = self._data.get(key)
+            if isinstance(value, str) and value.strip():
+                haystacks.append(value)
+
+        if not haystacks:
+            return None
+
+        combined = "\n".join(haystacks)
+        match = re.search(r"https?://notes\.granola\.ai/t/[A-Za-z0-9\-]+", combined)
+        return match.group(0) if match else None
+
+    def has_transcript_link(self) -> bool:
+        """Check if the meeting likely has a transcript link (even if not cached)."""
+        return self.transcript_url is not None
 
     def is_in_date_range(self, start_date: datetime.datetime, end_date: datetime.datetime) -> bool:
         """

--- a/granola_mcp/core/remote_api.py
+++ b/granola_mcp/core/remote_api.py
@@ -1,0 +1,318 @@
+"""Remote API client for GranolaMCP.
+
+Granola's desktop app can fetch transcripts from the Granola backend even when the
+local cache doesn't contain transcript segments. This module implements a minimal
+standard-library-only client that mirrors the app's behavior:
+- POST JSON to https://api.granola.ai/v1/<endpoint>
+- Use Bearer access tokens stored locally by the desktop app
+
+Notes on auth:
+- Granola's Electron app stores WorkOS tokens in
+  ~/Library/Application Support/Granola/supabase.json on macOS.
+- The file contains a JSON-encoded string under "workos_tokens" with
+  "access_token" and "refresh_token".
+
+This client intentionally avoids logging or persisting any secret values.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Tuple
+
+
+DEFAULT_API_BASE_URL = "https://api.granola.ai"
+DEFAULT_SUPABASE_PATH_MAC = "~/Library/Application Support/Granola/supabase.json"
+DEBUG_REMOTE_ENV = "GRANOLA_DEBUG_REMOTE"
+CLIENT_VERSION_ENV = "GRANOLA_CLIENT_VERSION"
+WORKSPACE_ID_ENV = "GRANOLA_WORKSPACE_ID"
+DEVICE_ID_ENV = "GRANOLA_DEVICE_ID"
+
+
+class GranolaRemoteError(RuntimeError):
+    """Raised when a remote Granola API operation fails."""
+
+
+def _debug_enabled() -> bool:
+    value = os.environ.get(DEBUG_REMOTE_ENV, "").strip().lower()
+    return value in {"1", "true", "yes", "y", "on"}
+
+
+def _debug(msg: str) -> None:
+    if _debug_enabled():
+        print(f"[granola-remote] {msg}", file=sys.stderr)
+
+
+def _read_json_file(path: str) -> Dict[str, Any]:
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    if not isinstance(data, dict):
+        raise GranolaRemoteError(f"Expected JSON object in {path}")
+    return data
+
+
+def load_workos_tokens(
+    supabase_path: Optional[str] = None,
+) -> Tuple[Optional[str], Optional[str]]:
+    """Load (access_token, refresh_token) from the local Granola app store.
+
+    Returns (None, None) if tokens can't be found.
+    """
+
+    env_path = os.environ.get("GRANOLA_SUPABASE_PATH")
+    candidate = supabase_path or env_path or DEFAULT_SUPABASE_PATH_MAC
+    candidate = os.path.expanduser(candidate)
+
+    if not os.path.exists(candidate):
+        return None, None
+
+    try:
+        root = _read_json_file(candidate)
+        workos_blob = root.get("workos_tokens")
+        if not isinstance(workos_blob, str) or not workos_blob.strip():
+            return None, None
+
+        decoded = json.loads(workos_blob)
+        if not isinstance(decoded, dict):
+            return None, None
+
+        access_token = decoded.get("access_token")
+        refresh_token = decoded.get("refresh_token")
+
+        if not isinstance(access_token, str) or not access_token.strip():
+            access_token = None
+        if not isinstance(refresh_token, str) or not refresh_token.strip():
+            refresh_token = None
+
+        return access_token, refresh_token
+    except Exception:
+        return None, None
+
+
+@dataclass
+class GranolaAPIClient:
+    """Minimal Granola backend API client."""
+
+    access_token: Optional[str] = None
+    refresh_token: Optional[str] = None
+    api_base_url: str = DEFAULT_API_BASE_URL
+    timeout_seconds: float = 15.0
+    client_version: Optional[str] = None
+    workspace_id: Optional[str] = None
+    device_id: Optional[str] = None
+
+    @classmethod
+    def from_local_app_data(
+        cls,
+        *,
+        client_version: Optional[str] = None,
+        workspace_id: Optional[str] = None,
+        device_id: Optional[str] = None,
+    ) -> "GranolaAPIClient":
+        access_token, refresh_token = load_workos_tokens()
+        return cls(
+            access_token=access_token,
+            refresh_token=refresh_token,
+            client_version=client_version or os.environ.get(CLIENT_VERSION_ENV),
+            workspace_id=workspace_id or os.environ.get(WORKSPACE_ID_ENV),
+            device_id=device_id or os.environ.get(DEVICE_ID_ENV),
+        )
+
+    def _build_headers(self) -> Dict[str, str]:
+        headers: Dict[str, str] = {
+            "Accept": "application/json",
+            "User-Agent": "GranolaMCP/1.0",
+        }
+
+        if self.access_token:
+            headers["Authorization"] = f"Bearer {self.access_token}"
+
+        if self.client_version and str(self.client_version).strip():
+            headers["X-Client-Version"] = str(self.client_version).strip()
+        else:
+            # The Electron app always sends X-Client-Version; keep one present.
+            headers["X-Client-Version"] = "GranolaMCP"
+
+        if self.workspace_id and str(self.workspace_id).strip():
+            headers["X-Granola-Workspace-Id"] = str(self.workspace_id).strip()
+
+        if self.device_id and str(self.device_id).strip():
+            headers["X-Granola-Device-Id"] = str(self.device_id).strip()
+
+        return headers
+
+    def _request_json(
+        self,
+        endpoint: str,
+        payload: Optional[Dict[str, Any]] = None,
+        *,
+        extra_headers: Optional[Dict[str, str]] = None,
+    ) -> Any:
+        url = f"{self.api_base_url.rstrip('/')}/v1/{endpoint.lstrip('/')}"
+
+        headers = self._build_headers()
+        if extra_headers:
+            for k, v in extra_headers.items():
+                if v is None:
+                    continue
+                headers[str(k)] = str(v)
+
+        body: Optional[bytes] = None
+        if payload is not None:
+            body = json.dumps(payload).encode("utf-8")
+            headers["Content-Type"] = "application/json"
+
+        req = urllib.request.Request(url, data=body, headers=headers, method="POST")
+
+        try:
+            with urllib.request.urlopen(req, timeout=self.timeout_seconds) as resp:
+                raw = resp.read().decode("utf-8", errors="replace")
+            return json.loads(raw) if raw else None
+        except urllib.error.HTTPError as e:
+            # Avoid leaking response bodies (could contain sensitive user data).
+            # In debug mode, emit only a small, best-effort safe summary.
+            if _debug_enabled():
+                try:
+                    raw_err = e.read(2048).decode("utf-8", errors="replace")
+                    if raw_err:
+                        try:
+                            parsed = json.loads(raw_err)
+                            if isinstance(parsed, dict):
+                                msg = parsed.get("message") or parsed.get("error")
+                                keys = sorted(parsed.keys())[:10]
+                                if isinstance(msg, str) and msg.strip():
+                                    _debug(f"{endpoint} error message: {msg[:200]}")
+                                else:
+                                    _debug(f"{endpoint} error keys: {keys}")
+                            else:
+                                _debug(f"{endpoint} error (non-dict JSON)")
+                        except Exception:
+                            _debug(f"{endpoint} error body (trunc): {raw_err[:200]}")
+                except Exception:
+                    pass
+
+            if e.code == 401:
+                _debug(f"HTTP 401 calling {endpoint}")
+                raise GranolaRemoteError("Unauthorized (401) calling Granola API") from e
+            _debug(f"HTTP {e.code} calling {endpoint}")
+            raise GranolaRemoteError(f"Granola API call failed: {endpoint} (HTTP {e.code})") from e
+        except urllib.error.URLError as e:
+            _debug(f"Connection error calling {endpoint}: {type(e).__name__}")
+            raise GranolaRemoteError(f"Granola API connection failed: {endpoint}") from e
+        except json.JSONDecodeError as e:
+            _debug(f"Invalid JSON from {endpoint}")
+            raise GranolaRemoteError(f"Granola API returned invalid JSON for {endpoint}") from e
+
+    def refresh_access_token(self) -> bool:
+        """Attempt to refresh the access token using refresh-access-token.
+
+        Returns True if the access token was updated in-memory.
+        """
+        if not self.refresh_token:
+            return False
+
+        response = None
+        errors: list[Exception] = []
+
+        payload_candidates = [
+            {"refresh_token": self.refresh_token},
+            {"refreshToken": self.refresh_token},
+        ]
+
+        for payload in payload_candidates:
+            try:
+                response = self._request_json("refresh-access-token", payload=payload)
+                break
+            except GranolaRemoteError as e:
+                errors.append(e)
+                continue
+
+        if response is None:
+            _ = errors
+            return False
+
+        if not isinstance(response, dict):
+            return False
+
+        new_access = response.get("access_token") or response.get("accessToken")
+        new_refresh = response.get("refresh_token") or response.get("refreshToken")
+
+        if isinstance(new_access, str) and new_access.strip():
+            self.access_token = new_access
+            if isinstance(new_refresh, str) and new_refresh.strip():
+                self.refresh_token = new_refresh
+            return True
+
+        return False
+
+    def get_document_transcript(self, document_id: str) -> Optional[Any]:
+        """Fetch transcript payload for a document.
+
+        Returns the transcript payload as either:
+        - list[dict] transcript segments, or
+        - a dict payload (caller can pass directly to Transcript)
+
+        Returns None when no transcript is available.
+        """
+
+        if not document_id:
+            return None
+
+        payload_candidates = [
+            {"document_id": document_id},
+            {"documentId": document_id},
+            {"id": document_id},
+        ]
+
+        last_error: Optional[Exception] = None
+        for payload in payload_candidates:
+            try:
+                response = self._request_json("get-document-transcript", payload=payload)
+            except GranolaRemoteError as e:
+                last_error = e
+                # If token expired, try refreshing once.
+                if "Unauthorized" in str(e) and self.refresh_access_token():
+                    try:
+                        response = self._request_json("get-document-transcript", payload=payload)
+                    except GranolaRemoteError as e2:
+                        last_error = e2
+                        continue
+                else:
+                    continue
+
+            if response is None:
+                return None
+
+            # Common shapes:
+            # - {"transcript": [...segments...]}
+            # - {"data": {"transcript": [...]}}
+            # - [...segments...]
+            if isinstance(response, list):
+                return response
+
+            if isinstance(response, dict):
+                if "transcript" in response:
+                    return response.get("transcript")
+                data = response.get("data")
+                if isinstance(data, dict) and "transcript" in data:
+                    return data.get("transcript")
+
+                # Some APIs nest under "data" as a list.
+                if isinstance(data, list):
+                    return data
+
+                # Some API responses may already be the transcript payload.
+                return response
+
+            # Unexpected type; treat as unavailable.
+            return None
+
+        # If every attempt failed, surface None (best-effort).
+        # Callers should not consider this fatal.
+        _ = last_error
+        return None

--- a/granola_mcp/mcp/tools.py
+++ b/granola_mcp/mcp/tools.py
@@ -152,8 +152,9 @@ class MCPTools:
                 continue
 
             # Search in transcript
-            if meeting.has_transcript() and meeting.transcript:
-                if query_lower in meeting.transcript.full_text.lower():
+            if meeting.has_transcript():
+                transcript = meeting.transcript
+                if transcript is not None and query_lower in transcript.full_text.lower():
                     matching_meetings.append(meeting)
                     continue
 
@@ -333,8 +334,11 @@ class MCPTools:
             }
 
             # Add transcript info if available
-            if meeting.has_transcript() and meeting.transcript:
+            if meeting.has_transcript():
                 transcript = meeting.transcript
+                if transcript is None:
+                    # Defensive: has_transcript() should imply transcript is not None
+                    return result
                 result["transcript_info"] = {
                     "word_count": transcript.word_count,
                     "speakers": transcript.speakers,
@@ -380,7 +384,7 @@ class MCPTools:
                 raise MCPToolError(f"Meeting has no transcript: {meeting_id}")
 
             transcript = meeting.transcript
-            if not transcript:
+            if transcript is None:
                 raise MCPToolError(f"Meeting transcript is None: {meeting_id}")
 
             # Build transcript response
@@ -454,7 +458,7 @@ class MCPTools:
             }
 
             # Add transcript summary if available
-            if meeting.has_transcript() and meeting.transcript:
+            if meeting.has_transcript() and meeting.transcript is not None:
                 transcript = meeting.transcript
 
                 # Basic transcript analysis
@@ -783,6 +787,11 @@ class MCPTools:
             if not meeting:
                 raise MCPToolError(f"Meeting not found: {meeting_id}")
 
+            # Force-load transcript if include_transcript is True
+            # This ensures transcript is available even if has_transcript() returns False
+            if include_transcript:
+                meeting.ensure_transcript(fetch_remote=True)
+                _ = meeting.transcript  # Force property access to load transcript
             # Use the existing markdown export function
             markdown_content = export_meeting_to_markdown(
                 meeting,


### PR DESCRIPTION
Adds best-effort remote transcript retrieval so transcripts are available even when not present in local cache.\n\nHighlights:\n- New stdlib-only client that calls https://api.granola.ai/v1/get-document-transcript using the desktop app's auth token + required headers\n- Meeting model resolves transcripts remotely by default (with opt-outs), so behavior is consistent across CLI + MCP tools\n- Keeps local/cache transcript behavior intact; remote fetch is best-effort\n\nControls:\n- CLI: per-command --no-remote disables remote fetch\n- Env: GRANOLA_FETCH_REMOTE_TRANSCRIPTS=0 disables remote fetching globally\n