### PR TITLE
fix: support Granola cache v4-v6 formats

### DIFF
--- a/granola_mcp/core/parser.py
+++ b/granola_mcp/core/parser.py
@@ -75,14 +75,17 @@ class GranolaParser:
                 raise GranolaParseError("Cache file missing required 'cache' field")
 
             cache_content = outer_data['cache']
-            if not isinstance(cache_content, str):
-                raise GranolaParseError("Cache field must contain a JSON string")
-
-            # Second JSON parse - parse the inner cache content
-            try:
-                self._cache_data = json.loads(cache_content)
-            except json.JSONDecodeError as e:
-                raise GranolaParseError(f"Invalid JSON in cache content: {e}") from e
+            if isinstance(cache_content, dict):
+                # v4 format: cache is already a parsed dict
+                self._cache_data = cache_content
+            elif isinstance(cache_content, str):
+                # v3 format: cache is a JSON string that needs second parse
+                try:
+                    self._cache_data = json.loads(cache_content)
+                except json.JSONDecodeError as e:
+                    raise GranolaParseError(f"Invalid JSON in cache content: {e}") from e
+            else:
+                raise GranolaParseError("Cache field must contain a JSON string or object")
 
             if not isinstance(self._cache_data, dict):
                 raise GranolaParseError("Cache content must be a JSON object")

--- a/granola_mcp/utils/config.py
+++ b/granola_mcp/utils/config.py
@@ -109,9 +109,15 @@ def get_cache_path(config: Optional[Dict[str, str]] = None) -> str:
         # Expand user home directory if needed
         return os.path.expanduser(cache_path)
 
-    # Default cache path
-    default_path = "/Users/pedram/Library/Application Support/Granola/cache-v3.json"
-    return os.path.expanduser(default_path)
+    # Default cache path - try versions from newest to oldest
+    home = os.path.expanduser("~")
+    for version in ("cache-v6.json", "cache-v5.json", "cache-v4.json", "cache-v3.json"):
+        candidate = os.path.join(home, "Library", "Application Support", "Granola", version)
+        if os.path.exists(candidate):
+            return candidate
+
+    # Fallback to latest known version path
+    return os.path.join(home, "Library", "Application Support", "Granola", "cache-v6.json")
 
 
 def get_config_value(key: str, default: Optional[str] = None, config: Optional[Dict[str, str]] = None) -> Optional[str]:


### PR DESCRIPTION
## Summary
- **parser.py**: Handle both `str` (v3) and `dict` (v4+) formats for the `cache` field, since newer Granola versions store the cache as a pre-parsed object instead of a JSON string
- **config.py**: Auto-detect cache files from v6 down to v3 instead of hardcoding a single user's v3 path. Uses `~` expansion so it works on any machine

## Context
Granola has been incrementally updating its local cache format. The current code only supports v3 (JSON string), which breaks for users on v4+ where the cache field is already a dict. The hardcoded default path (`/Users/pedram/...`) also doesn't work for other users.

## Test plan
- [x] Verified parser loads `cache-v6.json` successfully (108 meetings)
- [x] `get_cache_info()` returns `valid_structure: True`
- [ ] Backwards compatible — v3 string format still handled via `elif isinstance(cache_content, str)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)